### PR TITLE
Add correcting by caret position

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,12 @@ import Deasciifier from 'turkish-deasciifier';
 
 const deascii = new Deasciifier();
 
+deascii.correctWithRange = function(text, end){
+    var end = end ? end : text.length;
+    while(text.charAt(--end) == ' ');
+    return this.deasciifyRange(text, text.lastIndexOf(' ', end - 1), end);
+}
+
 const TurkishTextArea = React.createClass({
 
     getDefaultProps() {
@@ -47,7 +53,8 @@ const TurkishTextArea = React.createClass({
             return;
         }
 
-        const turkishValue = deascii.turkish_correct_last_word(e.target.value);
+        const end = e.target.selectionEnd, turkishValue = deascii.correctWithRange(e.target.value);
+        e.target.selectionEnd = end;
 
         if (this.props.onChange) {
             e.target.value = turkishValue;

--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,6 @@ const TurkishTextArea = React.createClass({
         }
 
         const end = e.target.selectionEnd, turkishValue = deascii.correctWithRange(e.target.value);
-        e.target.selectionEnd = end;
 
         if (this.props.onChange) {
             e.target.value = turkishValue;
@@ -62,6 +61,7 @@ const TurkishTextArea = React.createClass({
         } else {
             this.setValue(turkishValue);
         }
+        e.target.selectionEnd = end;
     },
 
     onPaste(e) {


### PR DESCRIPTION
Kullandığınız kütüphanenin, çağırdığınız fonksiyonu; verdiğiniz text'in son kelimesini düzelticek şekilde çalışıyor. Bu da textarea üzerinde navigasyon yapılıp, son kelime dışında herhangi bir kelimenin değişmesi/eklenmesi sonrasında Türkçe karkater düzeltmesi yapılmamasına sebep oluyor.

Localde npm ve proje gereksinimleri yüklü olmadığı için test edemedim. Basit bir html sayfası yapıp, onun üzerinde test ettim. Yazdığım kodun chrome üzerinde çalışıyor olması. Test ederseniz sevinirim.
